### PR TITLE
Properly display error messages from `pip install` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ***Fixed:***
 
+- Properly display error messages from `pip install` commands
 - Fix project version reading for the Starship prompt hidden command on non-Windows systems
 
 ## 0.2.0 - 2023-05-07

--- a/src/commands/self_cmd/update.rs
+++ b/src/commands/self_cmd/update.rs
@@ -46,7 +46,11 @@ impl Cli {
                 fs::remove_dir_all(&installation_directory).ok();
             }
 
-            println!("{}", String::from_utf8_lossy(&output.stdout));
+            println!(
+                "{}{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
             exit(output.status.code().unwrap_or(1));
         }
 

--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -131,7 +131,11 @@ pub fn install_project(installation_directory: &PathBuf, python: &PathBuf) -> Re
     let output = result?;
     if !output.status.success() {
         fs::remove_dir_all(installation_directory).ok();
-        println!("{}", String::from_utf8_lossy(&output.stdout));
+        println!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
         exit(output.status.code().unwrap_or(1));
     }
 


### PR DESCRIPTION
It's surprising that Rust does not have a way to merge the process output streams yet https://github.com/rust-lang/rfcs/issues/871