### PR TITLE
Move files over filesystem boundaries if necessary

### DIFF
--- a/src/distribution.rs
+++ b/src/distribution.rs
@@ -3,13 +3,11 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command, ExitStatus};
-use std::os::unix::fs::MetadataExt;
-
 
 use anyhow::{bail, Context, Result};
 use tempfile::tempdir;
 
-use crate::{app, compression, network, process};
+use crate::{app, compression, fs_utils, network, process};
 
 pub fn python_command(python: &PathBuf) -> Command {
     let mut command = Command::new(python);
@@ -124,42 +122,8 @@ pub fn materialize(installation_directory: &PathBuf) -> Result<()> {
         } else {
             network::download(&distribution_source, &mut f, "distribution")?;
         }
-        let temp_path_dev = fs::metadata(&temp_path).unwrap().dev();
-        // Distribution file does not exist yet
-        // Find first existing parent directory to determine mountpoint
-        let mut parent_dir = distributions_dir;
-        while !parent_dir.exists() {
-            parent_dir = parent_dir.parent().unwrap();
-        }
-        let distribution_file_dev = fs::metadata(&parent_dir).unwrap().dev();
 
-        // Check if target path and temp path are on the same device / mountpoint
-        if distribution_file_dev == temp_path_dev{
-            // If on the same device / mountpoint, rename the file
-            fs::rename(&temp_path, &distribution_file).with_context(|| {
-                format!(
-                    "unable to move {} to {}",
-                    &temp_path.display(),
-                    &distribution_file.display()
-                )
-            })?;
-        }
-        else {
-            // If on different devices / mountpoints, copy the file, then remove the temp file
-            fs::copy(&temp_path, &distribution_file).with_context(|| {
-                format!(
-                    "unable to copy {} to {}",
-                    &temp_path.display(),
-                    &distribution_file.display()
-                )
-            })?;
-            fs::remove_file(&temp_path).with_context(|| {
-                format!(
-                    "unable to remove {}",
-                    &temp_path.display()
-                )
-            })?;
-        }
+        fs_utils::move_temp_file(&temp_path, &distribution_file)?;
     }
 
     if app::full_isolation() {
@@ -330,13 +294,5 @@ fn ensure_pip() -> Result<()> {
         external_pip.file_name().unwrap().to_str().unwrap(),
     )?;
 
-    fs::rename(&temp_path, &external_pip).with_context(|| {
-        format!(
-            "unable to move {} to {}",
-            &temp_path.display(),
-            &external_pip.display()
-        )
-    })?;
-
-    Ok(())
+    fs_utils::move_temp_file(&temp_path, &external_pip)
 }

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -1,0 +1,21 @@
+use std::fs;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+pub fn move_temp_file(temp_file: &PathBuf, destination: &PathBuf) -> Result<()> {
+    if fs::rename(temp_file, destination).is_err() {
+        // If on different devices / mountpoints, copy the file, then remove the temp file
+        fs::copy(temp_file, destination).with_context(|| {
+            format!(
+                "unable to copy {} to {}",
+                temp_file.display(),
+                destination.display()
+            )
+        })?;
+        fs::remove_file(temp_file)
+            .with_context(|| format!("unable to remove temporary file {}", temp_file.display()))?;
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod app;
 mod commands;
 mod compression;
 mod distribution;
+mod fs_utils;
 mod network;
 mod process;
 mod terminal;


### PR DESCRIPTION
If the temporary directory the distribution is downloaded to is on a different filesystem/mountpoint than the final destination PyApp fails, since it tries to just rename the file. 

With this fix it is first checked if both paths are on the same filesystem, if not instead of renaming the file is copied and the source file is deleted.

Closes #37