### PR TITLE
Add notebook_exec option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,10 @@ flate2 = "1.0.26"
 indicatif = { version = "0.17.3", features = ["improved_unicode"] }
 once_cell = "1.17.1"
 os_pipe = "1.1.4"
-reqwest = { version = "0.11", features = ["blocking", "rustls-tls"], default-features = false }
+reqwest = { version = "0.11", features = [
+  "blocking",
+  "rustls-tls",
+], default-features = false }
 tar = "0.4.38"
 tempfile = "3.5.0"
 zip = { version = "0.6.4", features = ["deflate"] }
@@ -29,7 +32,10 @@ flate2 = "1.0.26"
 highway = "1.0.0"
 rand = "0.8.5"
 regex = "1.8.1"
-reqwest = { version = "0.11", features = ["blocking", "rustls-tls"], default-features = false }
+reqwest = { version = "0.11", features = [
+  "blocking",
+  "rustls-tls",
+], default-features = false }
 tar = "0.4.38"
 zip = { version = "0.6.4", features = ["deflate"] }
 
@@ -51,6 +57,7 @@ passthrough = [
   "PYAPP_EXEC_CODE",
   "PYAPP_EXEC_MODULE",
   "PYAPP_EXEC_SCRIPT",
+  "PYAPP_EXEC_NOTEBOOK",
   "PYAPP_EXEC_SPEC",
   "PYAPP_EXPOSE_METADATA",
   "PYAPP_EXPOSE_PIP",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,7 @@ flate2 = "1.0.26"
 indicatif = { version = "0.17.3", features = ["improved_unicode"] }
 once_cell = "1.17.1"
 os_pipe = "1.1.4"
-reqwest = { version = "0.11", features = [
-  "blocking",
-  "rustls-tls",
-], default-features = false }
+reqwest = { version = "0.11", features = ["blocking", "rustls-tls"], default-features = false }
 tar = "0.4.38"
 tempfile = "3.5.0"
 zip = { version = "0.6.4", features = ["deflate"] }
@@ -32,10 +29,7 @@ flate2 = "1.0.26"
 highway = "1.0.0"
 rand = "0.8.5"
 regex = "1.8.1"
-reqwest = { version = "0.11", features = [
-  "blocking",
-  "rustls-tls",
-], default-features = false }
+reqwest = { version = "0.11", features = ["blocking", "rustls-tls"], default-features = false }
 tar = "0.4.38"
 zip = { version = "0.6.4", features = ["deflate"] }
 
@@ -56,8 +50,8 @@ passthrough = [
   "PYAPP_DISTRIBUTION_VARIANT",
   "PYAPP_EXEC_CODE",
   "PYAPP_EXEC_MODULE",
-  "PYAPP_EXEC_SCRIPT",
   "PYAPP_EXEC_NOTEBOOK",
+  "PYAPP_EXEC_SCRIPT",
   "PYAPP_EXEC_SPEC",
   "PYAPP_EXPOSE_METADATA",
   "PYAPP_EXPOSE_PIP",

--- a/build.rs
+++ b/build.rs
@@ -701,6 +701,9 @@ fn set_execution_mode() {
     let script_variable = "PYAPP_EXEC_SCRIPT";
     let script = env::var(script_variable).unwrap_or_default();
 
+    let notebook_variable = "PYAPP_EXEC_NOTEBOOK";
+    let notebook = env::var(notebook_variable).unwrap_or_default();
+
     // Set defaults
     set_runtime_variable(module_variable, "");
     set_runtime_variable(code_variable, "");
@@ -708,19 +711,23 @@ fn set_execution_mode() {
     set_runtime_variable(script_variable, "");
     set_runtime_variable("PYAPP__EXEC_SCRIPT_NAME", "");
     set_runtime_variable("PYAPP__EXEC_SCRIPT_ID", "");
+    set_runtime_variable(notebook_variable, "");
+    set_runtime_variable("PYAPP__EXEC_NOTEBOOK_NAME", "");
+    set_runtime_variable("PYAPP__EXEC_NOTEBOOK_ID", "");
 
     if [
         module.is_empty(),
         spec.is_empty(),
         code.is_empty(),
         script.is_empty(),
+        notebook.is_empty(),
     ]
     .iter()
     .filter(|x| !(**x))
     .count()
         > 1
     {
-        panic!("\n\nThe {module_variable}, {spec_variable}, {code_variable}, and {script_variable} options are mutually exclusive\n\n");
+        panic!("\n\nThe {module_variable}, {spec_variable}, {code_variable}, {script_variable}, and {notebook_variable} options are mutually exclusive\n\n");
     } else if !module.is_empty() {
         set_runtime_variable(module_variable, &module);
     } else if !spec.is_empty() {
@@ -748,6 +755,21 @@ fn set_execution_mode() {
         set_runtime_variable(script_variable, STANDARD_NO_PAD.encode(contents));
         set_runtime_variable("PYAPP__EXEC_SCRIPT_NAME", file_name);
         set_runtime_variable("PYAPP__EXEC_SCRIPT_ID", hasher.finish());
+    } else if !notebook.is_empty() {
+        let path = PathBuf::from(&notebook);
+        if !path.is_file() {
+            panic!("\n\nNotebook is not a file: {notebook}\n\n");
+        }
+
+        let file_name = path.file_name().unwrap().to_str().unwrap();
+        let contents = fs::read_to_string(&path)
+            .unwrap_or_else(|_| panic!("\n\nFailed to read notebook: {notebook}\n\n"));
+        let mut hasher = PortableHash::default();
+        hasher.write(contents.as_bytes());
+
+        set_runtime_variable(notebook_variable, STANDARD_NO_PAD.encode(contents));
+        set_runtime_variable("PYAPP__EXEC_NOTEBOOK_NAME", file_name);
+        set_runtime_variable("PYAPP__EXEC_NOTEBOOK_ID", hasher.finish());
     } else {
         set_runtime_variable(
             module_variable,

--- a/src/app.rs
+++ b/src/app.rs
@@ -149,6 +149,17 @@ pub fn exec_script_path() -> PathBuf {
         .join(env!("PYAPP__EXEC_SCRIPT_NAME"))
 }
 
+pub fn exec_notebook() -> String {
+    decode_option(env!("PYAPP_EXEC_NOTEBOOK"))
+}
+
+pub fn exec_notebook_path() -> PathBuf {
+    cache_dir()
+        .join("notebooks")
+        .join(env!("PYAPP__EXEC_NOTEBOOK_ID"))
+        .join(env!("PYAPP__EXEC_NOTEBOOK_NAME"))
+}
+
 pub fn pip_extra_args() -> String {
     env!("PYAPP_PIP_EXTRA_ARGS").into()
 }


### PR DESCRIPTION
This PR adds a PYAPP_EXEC_NOTEBOOK execution option. It works in the same way as PYAPP_EXEC_SCRIPT but a .ipynb file needs to be specified instead of a .py file. The `-m notebook [file.ipynb]` command is called at runtime.