### PR TITLE
Ignore nonexistent variant options for 3.7 distributions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -316,7 +316,10 @@ fn get_distribution_source() -> String {
         if variant.is_empty() {
             if selected_platform == "windows" {
                 variant = "shared".to_string();
-            } else if selected_platform == "linux" && selected_arch == "x86_64" {
+            } else if selected_platform == "linux"
+                && selected_arch == "x86_64"
+                && selected_python_version != "3.7"
+            {
                 variant = "v3".to_string();
             }
         };

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Properly resolve correct default distributions on MinGW-w64
 - Fix embedding custom distributions
+- Ignore nonexistent variant options for 3.7 distributions
 
 ## 0.14.0 - 2024-01-21
 


### PR DESCRIPTION
Resolves https://github.com/ofek/pyapp/issues/87